### PR TITLE
FileWatcher: Do not create output directories until needed

### DIFF
--- a/pipescaler/core/pipeline.py
+++ b/pipescaler/core/pipeline.py
@@ -334,7 +334,7 @@ class Pipeline:
     def create_image_wip_directory(self, source_image: PipeImage):
         # Create image working directory
         image_wip_directory = validate_output_directory(
-            join(self.wip_directory, source_image.base_filename)
+            join(self.wip_directory, source_image.base_filename), create_directory=True
         )
 
         # Copy initial image to working directory

--- a/pipescaler/util/scaled_pair_identifier.py
+++ b/pipescaler/util/scaled_pair_identifier.py
@@ -75,7 +75,9 @@ class ScaledPairIdentifier:
         self.image_directory = None
         """Directory to which to write stacked scaled image sets"""
         if image_directory is not None:
-            self.image_directory = validate_output_directory(image_directory)
+            self.image_directory = validate_output_directory(
+                image_directory, create_directory=True
+            )
 
         # Prepare DatFrame of image hashes
         self.hashes = pd.DataFrame(


### PR DESCRIPTION
Closes #63.