### PR TITLE
Implement skip_if_codex mark for codex support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Instructions
+
+This repository uses `uv` for virtual environment management. Use `uv run` when executing tools.
+
+Common commands:
+
+- **Lint**: `uv run ruff check .`
+- **Format**: `uv run black .`
+- **Type check**: `uv run pyright`
+- **Tests**: `uv run pytest`

--- a/pipescaler/testing/mark.py
+++ b/pipescaler/testing/mark.py
@@ -63,6 +63,25 @@ def skip_if_ci(inner: partial | None = None) -> partial:
     return partial(param, marks=marks)
 
 
+def skip_if_codex(inner: partial | None = None) -> partial:
+    """Mark test to skip if running within Codex environment.
+
+    Arguments:
+        inner: Nascent partial function of pytest.param with additional marks
+    Returns:
+        Partial function of pytest.param with marks
+    """
+    marks = [
+        mark.skipif(
+            getenv("CODEX_ENV_PYTHON_VERSION") is not None,
+            reason="Skip when running in Codex environment",
+        )
+    ]
+    if inner:
+        marks.extend(inner.keywords["marks"])
+    return partial(param, marks=marks)
+
+
 def xfail_file_not_found(inner: partial | None = None) -> partial:
     """Mark test to be expected to fail due to a file that cannot be found.
 

--- a/test/image/cli/test_image_processors_cli.py
+++ b/test/image/cli/test_image_processors_cli.py
@@ -29,16 +29,16 @@ from pipescaler.image.cli.processors import (
     XbrzCli,
 )
 from pipescaler.testing.file import get_test_infile_path, get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @pytest.mark.parametrize(
     ("cli", "args", "infile"),
     [
         (CropCli, "--pixels 4 4 4 4", "RGB"),
-        skip_if_ci()(
+        skip_if_codex(skip_if_ci())(
             EsrganCli,
-            f"--model {get_test_model_infile_path('ESRGAN/1x_BC1-smooth2')}",
+            "--model ESRGAN/1x_BC1-smooth2",
             "RGB",
         ),
         (ExpandCli, "--pixels 8 8 8 8", "RGB"),
@@ -48,9 +48,9 @@ from pipescaler.testing.mark import skip_if_ci
         (SharpenCli, "", "RGB"),
         (SolidColorCli, "--scale 2", "RGB"),
         (ThresholdCli, "--threshold 64 --denoise", "L"),
-        skip_if_ci()(
+        skip_if_codex(skip_if_ci())(
             WaifuCli,
-            f"--model {get_test_model_infile_path('WaifuUpConv7/a-2-3')}",
+            "--model WaifuUpConv7/a-2-3",
             "RGB",
         ),
         (XbrzCli, "--scale 2", "RGB"),
@@ -58,6 +58,12 @@ from pipescaler.testing.mark import skip_if_ci
 )
 def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
     input_path = get_test_infile_path(infile)
+    if "ESRGAN/1x_BC1-smooth2" in args:
+        model_path = get_test_model_infile_path("ESRGAN/1x_BC1-smooth2")
+        args = args.replace("ESRGAN/1x_BC1-smooth2", str(model_path))
+    if "WaifuUpConv7/a-2-3" in args:
+        model_path = get_test_model_infile_path("WaifuUpConv7/a-2-3")
+        args = args.replace("WaifuUpConv7/a-2-3", str(model_path))
 
     with get_temp_file_path(".png") as output_path:
         run_cli_with_args(cli, f"{args} {input_path} {output_path}")

--- a/test/image/cli/test_image_processors_cli.py
+++ b/test/image/cli/test_image_processors_cli.py
@@ -1,4 +1,4 @@
-#  Copyright 2020-2024 Karl T Debiec. All rights reserved. This software may be modified
+#  Copyright 2020-2025 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """Tests for processor command-line interfaces."""
 from __future__ import annotations
@@ -38,7 +38,7 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
         (CropCli, "--pixels 4 4 4 4", "RGB"),
         skip_if_codex(skip_if_ci())(
             EsrganCli,
-            "--model ESRGAN/1x_BC1-smooth2",
+            f"--model {get_test_model_infile_path('ESRGAN/1x_BC1-smooth2')}",
             "RGB",
         ),
         (ExpandCli, "--pixels 8 8 8 8", "RGB"),
@@ -50,7 +50,7 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
         (ThresholdCli, "--threshold 64 --denoise", "L"),
         skip_if_codex(skip_if_ci())(
             WaifuCli,
-            "--model WaifuUpConv7/a-2-3",
+            f"--model {get_test_model_infile_path('WaifuUpConv7/a-2-3')}",
             "RGB",
         ),
         (XbrzCli, "--scale 2", "RGB"),
@@ -58,12 +58,6 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 )
 def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
     input_path = get_test_infile_path(infile)
-    if "ESRGAN/1x_BC1-smooth2" in args:
-        model_path = get_test_model_infile_path("ESRGAN/1x_BC1-smooth2")
-        args = args.replace("ESRGAN/1x_BC1-smooth2", str(model_path))
-    if "WaifuUpConv7/a-2-3" in args:
-        model_path = get_test_model_infile_path("WaifuUpConv7/a-2-3")
-        args = args.replace("WaifuUpConv7/a-2-3", str(model_path))
 
     with get_temp_file_path(".png") as output_path:
         run_cli_with_args(cli, f"{args} {input_path} {output_path}")

--- a/test/image/cli/test_image_utilities_cli.py
+++ b/test/image/cli/test_image_utilities_cli.py
@@ -17,18 +17,18 @@ from pipescaler.common.testing import run_cli_with_args
 from pipescaler.image.cli import ImageUtilitiesCli
 from pipescaler.image.cli.utilities import EsrganSerializerCli, WaifuSerializerCli
 from pipescaler.testing.file import get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @pytest.mark.parametrize(
     ("cli", "args", "infile"),
     [
-        skip_if_ci()(
+        skip_if_codex(skip_if_ci())(
             EsrganSerializerCli,
             "",
             "ESRGAN/1x_BC1-smooth2",
         ),
-        skip_if_ci()(
+        skip_if_codex(skip_if_ci())(
             WaifuSerializerCli,
             "upconv7",
             "WaifuUpConv7/a-2-1.json",

--- a/test/image/operators/processors/test_esrgan_processor.py
+++ b/test/image/operators/processors/test_esrgan_processor.py
@@ -19,8 +19,12 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
     [
         skip_if_codex(skip_if_ci())("1", "ESRGAN/1x_BC1-smooth2"),
         skip_if_codex(skip_if_ci())("L", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("LA", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("RGBA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "LA", "ESRGAN/1x_BC1-smooth2"
+        ),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "RGBA", "ESRGAN/1x_BC1-smooth2"
+        ),
         skip_if_codex(skip_if_ci())("RGB", "ESRGAN/1x_BC1-smooth2"),
         skip_if_codex(skip_if_ci())("RGB", "ESRGAN/1x_BC1-smooth2_out"),
         skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4"),
@@ -29,9 +33,13 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
         skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch"),
         skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch_out"),
         skip_if_codex(skip_if_ci())("PL", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PLA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "PLA", "ESRGAN/1x_BC1-smooth2"
+        ),
         skip_if_codex(skip_if_ci())("PRGB", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PRGBA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "PRGBA", "ESRGAN/1x_BC1-smooth2"
+        ),
     ],
 )
 def test(infile: str, model: str) -> None:

--- a/test/image/operators/processors/test_esrgan_processor.py
+++ b/test/image/operators/processors/test_esrgan_processor.py
@@ -10,28 +10,28 @@ from pipescaler.image.testing import (
     xfail_unsupported_image_mode,
 )
 from pipescaler.testing.file import get_test_infile_path, get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize(
     ("infile", "model"),
     [
-        skip_if_ci()("1", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci()("L", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci(xfail_unsupported_image_mode())("LA", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci(xfail_unsupported_image_mode())("RGBA", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci()("RGB", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci()("RGB", "ESRGAN/1x_BC1-smooth2_out"),
-        skip_if_ci()("RGB", "ESRGAN/RRDB_ESRGAN_x4"),
-        skip_if_ci()("RGB", "ESRGAN/RRDB_ESRGAN_x4_out"),
-        skip_if_ci()("RGB", "ESRGAN/1x_BC1-smooth2_out"),
-        skip_if_ci()("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch"),
-        skip_if_ci()("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch_out"),
-        skip_if_ci()("PL", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci(xfail_unsupported_image_mode())("PLA", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci()("PRGB", "ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci(xfail_unsupported_image_mode())("PRGBA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("1", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("L", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("LA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("RGBA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/1x_BC1-smooth2_out"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4_out"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/1x_BC1-smooth2_out"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch"),
+        skip_if_codex(skip_if_ci())("RGB", "ESRGAN/RRDB_ESRGAN_x4_old_arch_out"),
+        skip_if_codex(skip_if_ci())("PL", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PLA", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("PRGB", "ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PRGBA", "ESRGAN/1x_BC1-smooth2"),
     ],
 )
 def test(infile: str, model: str) -> None:

--- a/test/image/operators/processors/test_waifu_external_processor.py
+++ b/test/image/operators/processors/test_waifu_external_processor.py
@@ -11,7 +11,7 @@ from pipescaler.image.testing import (
 )
 from pipescaler.testing.file import get_test_infile_path
 from pipescaler.testing.fixture import parametrized_fixture
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @parametrized_fixture(
@@ -29,14 +29,14 @@ def processor(request) -> WaifuExternalProcessor:
 @pytest.mark.parametrize(
     "infile",
     [
-        skip_if_ci()("L"),
-        skip_if_ci(xfail_unsupported_image_mode())("LA"),
-        skip_if_ci()("RGB"),
-        skip_if_ci(xfail_unsupported_image_mode())("RGBA"),
-        skip_if_ci()("PL"),
-        skip_if_ci(xfail_unsupported_image_mode())("PLA"),
-        skip_if_ci()("PRGB"),
-        skip_if_ci(xfail_unsupported_image_mode())("PRGBA"),
+        skip_if_codex(skip_if_ci())("L"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("LA"),
+        skip_if_codex(skip_if_ci())("RGB"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("RGBA"),
+        skip_if_codex(skip_if_ci())("PL"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PLA"),
+        skip_if_codex(skip_if_ci())("PRGB"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))("PRGBA"),
     ],
 )
 def test(infile: str, processor: WaifuExternalProcessor) -> None:

--- a/test/image/operators/processors/test_waifu_processor.py
+++ b/test/image/operators/processors/test_waifu_processor.py
@@ -10,19 +10,25 @@ from pipescaler.image.testing import (
     xfail_unsupported_image_mode,
 )
 from pipescaler.testing.file import get_test_infile_path, get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize(
     ("infile", "model"),
     [
-        skip_if_ci(xfail_unsupported_image_mode())("1", "WaifuUpConv7/a-2-3"),
-        skip_if_ci()("L", "WaifuUpConv7/a-2-3"),
-        skip_if_ci(xfail_unsupported_image_mode())("LA", "WaifuUpConv7/a-2-3"),
-        skip_if_ci()("RGB", "WaifuUpConv7/a-2-3"),
-        skip_if_ci()("RGB", "WaifuVgg7/a-1-3"),
-        skip_if_ci(xfail_unsupported_image_mode())("RGBA", "WaifuUpConv7/a-2-3"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "1", "WaifuUpConv7/a-2-3"
+        ),
+        skip_if_codex(skip_if_ci())("L", "WaifuUpConv7/a-2-3"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "LA", "WaifuUpConv7/a-2-3"
+        ),
+        skip_if_codex(skip_if_ci())("RGB", "WaifuUpConv7/a-2-3"),
+        skip_if_codex(skip_if_ci())("RGB", "WaifuVgg7/a-1-3"),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "RGBA", "WaifuUpConv7/a-2-3"
+        ),
     ],
 )
 def test(infile: str, model: str) -> None:

--- a/test/image/runners/test_waifu_runner.py
+++ b/test/image/runners/test_waifu_runner.py
@@ -9,7 +9,7 @@ from pipescaler.common.file import get_temp_file_path
 from pipescaler.image.runners import WaifuRunner
 from pipescaler.testing.file import get_test_infile_path
 from pipescaler.testing.fixture import parametrized_fixture
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @parametrized_fixture(
@@ -25,7 +25,7 @@ def runner(request) -> WaifuRunner:
 @pytest.mark.parametrize(
     "infile_name",
     [
-        skip_if_ci()("RGB"),
+        skip_if_codex(skip_if_ci())("RGB"),
     ],
 )
 def test(infile_name: str, runner: WaifuRunner) -> None:

--- a/test/image/test_subdivided_image.py
+++ b/test/image/test_subdivided_image.py
@@ -14,7 +14,7 @@ from pipescaler.image.operators.processors import (
 )
 from pipescaler.image.testing import xfail_unsupported_image_mode
 from pipescaler.testing.file import get_test_infile_path, get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @pytest.fixture
@@ -49,12 +49,14 @@ def potrace_processor() -> PotraceProcessor:
 @pytest.mark.parametrize(
     ("processor_name", "infile", "scale"),
     [
-        skip_if_ci()("esrgan_bc1s2_processor", "L", 1),
-        skip_if_ci()("esrgan_bc1s2_processor", "RGB", 1),
-        skip_if_ci(xfail_unsupported_image_mode())("esrgan_bc1s2_processor", "RGBA", 1),
-        skip_if_ci()("esrgan_rrdb_processor", "RGB", 4),
+        skip_if_codex(skip_if_ci())("esrgan_bc1s2_processor", "L", 1),
+        skip_if_codex(skip_if_ci())("esrgan_bc1s2_processor", "RGB", 1),
+        skip_if_codex(skip_if_ci(xfail_unsupported_image_mode()))(
+            "esrgan_bc1s2_processor", "RGBA", 1
+        ),
+        skip_if_codex(skip_if_ci())("esrgan_rrdb_processor", "RGB", 4),
         ("potrace_processor", "L", 10),
-        skip_if_ci()("waifu_processor", "RGB", 2),
+        skip_if_codex(skip_if_ci())("waifu_processor", "RGB", 2),
         ("xbrz_processor", "RGB", 6),
     ],
 )

--- a/test/image/utilities/test_esrgan_serializer.py
+++ b/test/image/utilities/test_esrgan_serializer.py
@@ -8,7 +8,7 @@ from pytest import fixture, mark
 from pipescaler.common.file import get_temp_file_path
 from pipescaler.image.utilities import EsrganSerializer
 from pipescaler.testing.file import get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @fixture
@@ -19,9 +19,9 @@ def utility(request) -> EsrganSerializer:
 @mark.parametrize(
     "infile",
     [
-        skip_if_ci()("ESRGAN/1x_BC1-smooth2"),
-        skip_if_ci()("ESRGAN/RRDB_ESRGAN_x4"),
-        skip_if_ci()("ESRGAN/RRDB_ESRGAN_x4_old_arch"),
+        skip_if_codex(skip_if_ci())("ESRGAN/1x_BC1-smooth2"),
+        skip_if_codex(skip_if_ci())("ESRGAN/RRDB_ESRGAN_x4"),
+        skip_if_codex(skip_if_ci())("ESRGAN/RRDB_ESRGAN_x4_old_arch"),
     ],
 )
 def test(infile: str, utility: EsrganSerializer) -> None:

--- a/test/image/utilities/test_waifu_serializer.py
+++ b/test/image/utilities/test_waifu_serializer.py
@@ -8,7 +8,7 @@ from pytest import fixture, mark
 from pipescaler.common.file import get_temp_file_path
 from pipescaler.image.utilities import WaifuSerializer
 from pipescaler.testing.file import get_test_model_infile_path
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 
 
 @fixture
@@ -19,8 +19,8 @@ def utility(request) -> WaifuSerializer:
 @mark.parametrize(
     ("architecture", "infile"),
     [
-        skip_if_ci()("upconv7", "WaifuUpConv7/a-2-1.json"),
-        skip_if_ci()("vgg7", "WaifuVgg7/a-2-0.json"),
+        skip_if_codex(skip_if_ci())("upconv7", "WaifuUpConv7/a-2-1.json"),
+        skip_if_codex(skip_if_ci())("vgg7", "WaifuVgg7/a-2-0.json"),
     ],
 )
 def test(architecture: str, infile: str, utility: WaifuSerializer) -> None:

--- a/test/video/runners/test_apngasm_runner.py
+++ b/test/video/runners/test_apngasm_runner.py
@@ -9,7 +9,7 @@ from PIL import Image
 from pipescaler.common.file import get_temp_file_path
 from pipescaler.testing.file import get_test_infile_path
 from pipescaler.testing.fixture import parametrized_fixture
-from pipescaler.testing.mark import skip_if_ci
+from pipescaler.testing.mark import skip_if_ci, skip_if_codex
 from pipescaler.video.runners import ApngasmRunner
 
 
@@ -26,7 +26,7 @@ def runner(request) -> ApngasmRunner:
 @pytest.mark.parametrize(
     "infile_names",
     [
-        skip_if_ci()(["1", "L", "RGB", "RGBA"]),
+        skip_if_codex(skip_if_ci())(["1", "L", "RGB", "RGBA"]),
     ],
 )
 def test(infile_names: list[str], runner: ApngasmRunner) -> None:


### PR DESCRIPTION
## Summary
- drop standalone skip_if_codex test
- add helper notes in `AGENTS.md`
- mark ESRGAN tests with `skip_if_codex`

## Testing
- `uv run ruff check . | head -n 20`
- `uv run pyright | head -n 20`
- `uv run pytest test/image/utilities/test_esrgan_serializer.py::test -vv`
- `uv run pytest test/image/operators/processors/test_esrgan_processor.py::test -vv`


------
https://chatgpt.com/codex/tasks/task_e_68410739e28c8325a904ad5c2d089a3a