### PR TITLE
Use built-in type

### DIFF
--- a/pipescaler/cli/pipescaler_cli.py
+++ b/pipescaler/cli/pipescaler_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.cli import ImageCli
@@ -39,7 +39,7 @@ class PipeScalerCli(CommandLineInterface):
         subcommand_cli_class._main(**kwargs)
 
     @classmethod
-    def subcommands(cls) -> dict[str, Type[ImageCli]]:
+    def subcommands(cls) -> dict[str, type[ImageCli]]:
         """Names and types of tools wrapped by command-line interface."""
         return {
             ImageCli.name(): ImageCli,

--- a/pipescaler/core/cli/utility_cli.py
+++ b/pipescaler/core/cli/utility_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from inspect import cleandoc
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.core.utility import Utility
@@ -39,6 +39,6 @@ class UtilityCli(CommandLineInterface, ABC):
 
     @classmethod
     @abstractmethod
-    def utility(cls) -> Type[Utility]:
+    def utility(cls) -> type[Utility]:
         """Type of utility wrapped by command-line interface."""
         raise NotImplementedError()

--- a/pipescaler/image/cli/image_cli.py
+++ b/pipescaler/image/cli/image_cli.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.cli.image_processors_cli import ImageProcessorsCli
@@ -56,7 +56,7 @@ class ImageCli(CommandLineInterface):
     @classmethod
     def subcommands(
         cls,
-    ) -> dict[str, Type[ImageProcessorsCli] | Type[ImageUtilitiesCli]]:
+    ) -> dict[str, type[ImageProcessorsCli] | type[ImageUtilitiesCli]]:
         """Names and types of tools wrapped by command-line interface."""
         return {
             ImageProcessorsCli.name(): ImageProcessorsCli,

--- a/pipescaler/image/cli/image_mergers_cli.py
+++ b/pipescaler/image/cli/image_mergers_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.cli import mergers
@@ -55,7 +55,7 @@ class ImageMergersCli(CommandLineInterface):
         return "merge"
 
     @classmethod
-    def mergers(cls) -> dict[str, Type[ImageMergerCli]]:
+    def mergers(cls) -> dict[str, type[ImageMergerCli]]:
         """Names and types of mergers wrapped by command-line interface."""
         return {
             merger.name(): merger

--- a/pipescaler/image/cli/image_processors_cli.py
+++ b/pipescaler/image/cli/image_processors_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.cli import processors
@@ -55,7 +55,7 @@ class ImageProcessorsCli(CommandLineInterface):
         return "process"
 
     @classmethod
-    def processors(cls) -> dict[str, Type[ImageProcessorCli]]:
+    def processors(cls) -> dict[str, type[ImageProcessorCli]]:
         """Names and types of processors wrapped by command-line interface."""
         return {
             processor.name(): processor

--- a/pipescaler/image/cli/image_splitters_cli.py
+++ b/pipescaler/image/cli/image_splitters_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.cli import splitters
@@ -55,7 +55,7 @@ class ImageSplittersCli(CommandLineInterface):
         return "merge"
 
     @classmethod
-    def splitters(cls) -> dict[str, Type[ImageSplitterCli]]:
+    def splitters(cls) -> dict[str, type[ImageSplitterCli]]:
         """Names and types of splitters wrapped by command-line interface."""
         return {
             splitter.name(): splitter

--- a/pipescaler/image/cli/image_utilities_cli.py
+++ b/pipescaler/image/cli/image_utilities_cli.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Any, Type
+from typing import Any
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.core.cli import UtilityCli
@@ -55,7 +55,7 @@ class ImageUtilitiesCli(CommandLineInterface):
         return "utility"
 
     @classmethod
-    def utilities(cls) -> dict[str, Type[UtilityCli]]:
+    def utilities(cls) -> dict[str, type[UtilityCli]]:
         """Names and types of utilities wrapped by command-line interface."""
         return {
             utility.name(): utility

--- a/pipescaler/image/cli/mergers/alpha_merger_cli.py
+++ b/pipescaler/image/cli/mergers/alpha_merger_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import info
-from typing import Any, Type
+from typing import Any
 
 from PIL import Image
 
@@ -60,7 +60,7 @@ class AlphaMergerCli(ImageMergerCli):
             info(f"{cls}: '{outfile}' saved")
 
     @classmethod
-    def merger(cls) -> Type[AlphaMerger]:
+    def merger(cls) -> type[AlphaMerger]:
         """Type of merger wrapped by command-line interface."""
         return AlphaMerger
 

--- a/pipescaler/image/cli/mergers/palette_match_merger_cli.py
+++ b/pipescaler/image/cli/mergers/palette_match_merger_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import info
-from typing import Any, Type
+from typing import Any
 
 from PIL import Image
 
@@ -83,7 +83,7 @@ class PaletteMatchMergerCli(ImageMergerCli):
             info(f"{cls}: '{outfile}' saved")
 
     @classmethod
-    def merger(cls) -> Type[PaletteMatchMerger]:
+    def merger(cls) -> type[PaletteMatchMerger]:
         """Type of merger wrapped by command-line interface."""
         return PaletteMatchMerger
 

--- a/pipescaler/image/cli/processors/crop_cli.py
+++ b/pipescaler/image/cli/processors/crop_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import get_arg_groups_by_name, int_arg
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -40,7 +39,7 @@ class CropCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[CropProcessor]:
+    def processor(cls) -> type[CropProcessor]:
         """Type of processor wrapped by command-line interface."""
         return CropProcessor
 

--- a/pipescaler/image/cli/processors/esrgan_cli.py
+++ b/pipescaler/image/cli/processors/esrgan_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -50,7 +49,7 @@ class EsrganCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[EsrganProcessor]:
+    def processor(cls) -> type[EsrganProcessor]:
         """Type of processor wrapped by command-line interface."""
         return EsrganProcessor
 

--- a/pipescaler/image/cli/processors/expand_cli.py
+++ b/pipescaler/image/cli/processors/expand_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import get_arg_groups_by_name, int_arg
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -41,7 +40,7 @@ class ExpandCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[ExpandProcessor]:
+    def processor(cls) -> type[ExpandProcessor]:
         """Type of processor wrapped by command-line interface."""
         return ExpandProcessor
 

--- a/pipescaler/image/cli/processors/height_to_normal_cli.py
+++ b/pipescaler/image/cli/processors/height_to_normal_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import float_arg, get_arg_groups_by_name
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -39,7 +38,7 @@ class HeightToNormalCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[HeightToNormalProcessor]:
+    def processor(cls) -> type[HeightToNormalProcessor]:
         """Type of processor wrapped by command-line interface."""
         return HeightToNormalProcessor
 

--- a/pipescaler/image/cli/processors/mode_cli.py
+++ b/pipescaler/image/cli/processors/mode_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import get_arg_groups_by_name, str_arg
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -53,7 +52,7 @@ class ModeCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[ModeProcessor]:
+    def processor(cls) -> type[ModeProcessor]:
         """Type of processor wrapped by command-line interface."""
         return ModeProcessor
 

--- a/pipescaler/image/cli/processors/resize_cli.py
+++ b/pipescaler/image/cli/processors/resize_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import (
     float_arg,
@@ -49,7 +48,7 @@ class ResizeCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[ResizeProcessor]:
+    def processor(cls) -> type[ResizeProcessor]:
         """Type of processor wrapped by command-line interface."""
         return ResizeProcessor
 

--- a/pipescaler/image/cli/processors/sharpen_cli.py
+++ b/pipescaler/image/cli/processors/sharpen_cli.py
@@ -4,7 +4,6 @@
 """Command-line interface for SharpenProcessor."""
 from __future__ import annotations
 
-from typing import Type
 
 from pipescaler.image.core.cli import ImageProcessorCli
 from pipescaler.image.operators.processors import SharpenProcessor
@@ -14,7 +13,7 @@ class SharpenCli(ImageProcessorCli):
     """Command-line interface for SharpenProcessor."""
 
     @classmethod
-    def processor(cls) -> Type[SharpenProcessor]:
+    def processor(cls) -> type[SharpenProcessor]:
         """Type of processor wrapped by command-line interface."""
         return SharpenProcessor
 

--- a/pipescaler/image/cli/processors/solid_color_cli.py
+++ b/pipescaler/image/cli/processors/solid_color_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import float_arg, get_arg_groups_by_name
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -38,7 +37,7 @@ class SolidColorCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[SolidColorProcessor]:
+    def processor(cls) -> type[SolidColorProcessor]:
         """Type of processor wrapped by command-line interface."""
         return SolidColorProcessor
 

--- a/pipescaler/image/cli/processors/threshold_cli.py
+++ b/pipescaler/image/cli/processors/threshold_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import get_arg_groups_by_name, int_arg
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -45,7 +44,7 @@ class ThresholdCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[ThresholdProcessor]:
+    def processor(cls) -> type[ThresholdProcessor]:
         """Type of processor wrapped by command-line interface."""
         return ThresholdProcessor
 

--- a/pipescaler/image/cli/processors/waifu_cli.py
+++ b/pipescaler/image/cli/processors/waifu_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -50,7 +49,7 @@ class WaifuCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[WaifuProcessor]:
+    def processor(cls) -> type[WaifuProcessor]:
         """Type of processor wrapped by command-line interface."""
         return WaifuProcessor
 

--- a/pipescaler/image/cli/processors/xbrz_cli.py
+++ b/pipescaler/image/cli/processors/xbrz_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import get_arg_groups_by_name, int_arg
 from pipescaler.image.core.cli import ImageProcessorCli
@@ -38,7 +37,7 @@ class XbrzCli(ImageProcessorCli):
         )
 
     @classmethod
-    def processor(cls) -> Type[XbrzProcessor]:
+    def processor(cls) -> type[XbrzProcessor]:
         """Type of processor wrapped by command-line interface."""
         return XbrzProcessor
 

--- a/pipescaler/image/cli/splitters/alpha_splitter_cli.py
+++ b/pipescaler/image/cli/splitters/alpha_splitter_cli.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import info
-from typing import Any, Type
+from typing import Any
 
 from PIL import Image
 
@@ -55,7 +55,7 @@ class AlphaSplitterCli(ImageSplitterCli):
             info(f"{cls}: '{alpha_outfile}' saved")
 
     @classmethod
-    def splitter(cls) -> Type[ImageSplitter]:
+    def splitter(cls) -> type[ImageSplitter]:
         """Type of splitter wrapped by command-line interface."""
         return AlphaSplitter
 

--- a/pipescaler/image/cli/utilities/esrgan_serializer_cli.py
+++ b/pipescaler/image/cli/utilities/esrgan_serializer_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -46,7 +45,7 @@ class EsrganSerializerCli(UtilityCli):
         )
 
     @classmethod
-    def utility(cls) -> Type[EsrganSerializer]:
+    def utility(cls) -> type[EsrganSerializer]:
         """Type of utility wrapped by command-line interface."""
         return EsrganSerializer
 

--- a/pipescaler/image/cli/utilities/waifu_serializer_cli.py
+++ b/pipescaler/image/cli/utilities/waifu_serializer_cli.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
-from typing import Type
 
 from pipescaler.common.argument_parsing import (
     get_arg_groups_by_name,
@@ -52,7 +51,7 @@ class WaifuSerializerCli(UtilityCli):
         )
 
     @classmethod
-    def utility(cls) -> Type[WaifuSerializer]:
+    def utility(cls) -> type[WaifuSerializer]:
         """Type of utility wrapped by command-line interface."""
         return WaifuSerializer
 

--- a/pipescaler/image/core/cli/image_merger_cli.py
+++ b/pipescaler/image/core/cli/image_merger_cli.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from inspect import cleandoc
-from typing import Type
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.image.core.operators import ImageMerger
@@ -27,6 +26,6 @@ class ImageMergerCli(CommandLineInterface, ABC):
 
     @classmethod
     @abstractmethod
-    def merger(cls) -> Type[ImageMerger]:
+    def merger(cls) -> type[ImageMerger]:
         """Type of merger wrapped by command-line interface."""
         raise NotImplementedError()

--- a/pipescaler/image/core/cli/image_processor_cli.py
+++ b/pipescaler/image/core/cli/image_processor_cli.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from argparse import ArgumentParser
 from inspect import cleandoc
 from logging import info
-from typing import Any, Type
+from typing import Any
 
 from PIL import Image
 
@@ -64,6 +64,6 @@ class ImageProcessorCli(CommandLineInterface, ABC):
 
     @classmethod
     @abstractmethod
-    def processor(cls) -> Type[ImageProcessor]:
+    def processor(cls) -> type[ImageProcessor]:
         """Type of processor wrapped by command-line interface."""
         raise NotImplementedError()

--- a/pipescaler/image/core/cli/image_splitter_cli.py
+++ b/pipescaler/image/core/cli/image_splitter_cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser
 from inspect import cleandoc
-from typing import Type
 
 from pipescaler.common import CommandLineInterface
 from pipescaler.common.argument_parsing import input_file_arg
@@ -44,6 +43,6 @@ class ImageSplitterCli(CommandLineInterface, ABC):
 
     @classmethod
     @abstractmethod
-    def splitter(cls) -> Type[ImageSplitter]:
+    def splitter(cls) -> type[ImageSplitter]:
         """Type of splitter wrapped by command-line interface."""
         raise NotImplementedError()

--- a/pipescaler/testing/fixture.py
+++ b/pipescaler/testing/fixture.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Type
+from typing import Any
 
 from pytest import fixture
 
 
-def parametrized_fixture(cls: Type, params: list[dict[str, Any]]):
+def parametrized_fixture(cls: type, params: list[dict[str, Any]]):
     """Decorator for parametrized test fixtures which provides clearer test output.
 
     Arguments:

--- a/pipescaler/testing/mark.py
+++ b/pipescaler/testing/mark.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from functools import partial
 from os import getenv
 from platform import system
-from typing import Any, Type
+from typing import Any
 
 from pytest import mark, param
 
@@ -98,7 +98,7 @@ def xfail_file_not_found(inner: partial | None = None) -> partial:
 
 def xfail_if_platform(
     unsupported_platforms: set[str] | None = None,
-    raises: Type[Exception] = UnsupportedPlatformError,
+    raises: type[Exception] = UnsupportedPlatformError,
     inner: partial | None = None,
 ) -> partial:
     """Mark test to be expected to fail on selected platforms.

--- a/scripts/readme_updater.py
+++ b/scripts/readme_updater.py
@@ -8,7 +8,6 @@ import re
 from inspect import getfile
 from pathlib import Path, PurePosixPath
 from types import ModuleType
-from typing import Type
 
 import pipescaler.image.operators.mergers as image_mergers
 import pipescaler.image.operators.processors as image_processors
@@ -25,7 +24,7 @@ from pipescaler.core.pipelines.sorter import Sorter
 from pipescaler.image.core import ImageOperator
 
 
-def get_github_link(cls: Type[ImageOperator]) -> str:
+def get_github_link(cls: type[ImageOperator]) -> str:
     """Get the GitHub master branch link to the file containing a class.
 
     Arguments:
@@ -62,7 +61,7 @@ def get_module_regexes(modules: list[ModuleType]) -> dict[ModuleType, re.Pattern
     return module_regexes
 
 
-def get_stage_description(stage: Type[ImageOperator]) -> str:
+def get_stage_description(stage: type[ImageOperator]) -> str:
     """Get the formatted description of a stage, including GitHub link.
 
     Uses the first block of lines in the Stage's docstring.

--- a/test/cli/test_pipescaler_cli.py
+++ b/test/cli/test_pipescaler_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -25,7 +24,7 @@ from pipescaler.testing.mark import parametrize_with_readable_ids
         (PipeScalerCli, ImageCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -49,7 +48,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (PipeScalerCli, ImageCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()

--- a/test/image/cli/test_image_cli.py
+++ b/test/image/cli/test_image_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -24,7 +23,7 @@ from pipescaler.image.cli import ImageCli, ImageProcessorsCli, ImageUtilitiesCli
         (ImageCli, ImageUtilitiesCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -49,7 +48,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (ImageCli, ImageUtilitiesCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()

--- a/test/image/cli/test_image_mergers_cli.py
+++ b/test/image/cli/test_image_mergers_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -28,7 +27,7 @@ from pipescaler.testing.file import get_test_infile_path
         (PaletteMatchMergerCli, "--local --local_range 2", ("RGB", "alt/RGB")),
     ],
 )
-def test(cli: Type[CommandLineInterface], args: str, infiles: tuple[str]) -> None:
+def test(cli: type[CommandLineInterface], args: str, infiles: tuple[str]) -> None:
     input_paths = [str(get_test_infile_path(infile)) for infile in infiles]
 
     with get_temp_file_path(".png") as output_path:
@@ -45,7 +44,7 @@ def test(cli: Type[CommandLineInterface], args: str, infiles: tuple[str]) -> Non
         (ImageMergersCli, PaletteMatchMergerCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -72,7 +71,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (ImageMergersCli, PaletteMatchMergerCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()

--- a/test/image/cli/test_image_processors_cli.py
+++ b/test/image/cli/test_image_processors_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -56,7 +55,7 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
         (XbrzCli, "--scale 2", "RGB"),
     ],
 )
-def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
+def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
     input_path = get_test_infile_path(infile)
 
     with get_temp_file_path(".png") as output_path:
@@ -91,7 +90,7 @@ def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
         (ImageProcessorsCli, XbrzCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -136,7 +135,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (ImageProcessorsCli, XbrzCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()

--- a/test/image/cli/test_image_splitters_cli.py
+++ b/test/image/cli/test_image_splitters_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -25,7 +24,7 @@ from pipescaler.testing.file import get_test_infile_path
         (AlphaSplitterCli, "", "RGBA"),
     ],
 )
-def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
+def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
     input_path = get_test_infile_path(infile)
 
     with get_temp_file_path(".png") as output_path_1:
@@ -43,7 +42,7 @@ def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
         (ImageSplittersCli, AlphaSplitterCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -68,7 +67,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (ImageSplittersCli, AlphaSplitterCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()

--- a/test/image/cli/test_image_utilities_cli.py
+++ b/test/image/cli/test_image_utilities_cli.py
@@ -7,7 +7,6 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -35,7 +34,7 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
         ),
     ],
 )
-def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
+def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
     input_path = get_test_model_infile_path(infile)
 
     with get_temp_file_path(".pth") as output_path:
@@ -52,7 +51,7 @@ def test(cli: Type[CommandLineInterface], args: str, infile: str) -> None:
         (ImageUtilitiesCli, WaifuSerializerCli),
     ],
 )
-def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
+def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -79,7 +78,7 @@ def test_help(commands: tuple[Type[CommandLineInterface], ...]) -> None:
         (ImageUtilitiesCli, WaifuSerializerCli),
     ],
 )
-def test_usage(commands: tuple[Type[CommandLineInterface], ...]):
+def test_usage(commands: tuple[type[CommandLineInterface], ...]):
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()


### PR DESCRIPTION
## Summary
- drop `Type` import in CLI, tests, and utilities
- replace `Type[...]` with `type[...]`

## Testing
- `uv run black .`
- `uv run ruff check .` *(fails: Found 187 errors)*
- `uv run pyright` *(fails: multiple type errors)*
- `uv run pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68411ad2fc988325af8906ce2202ed67