### PR TITLE
Fix import for Sequence

### DIFF
--- a/pipescaler/core/pipelines/checkpointed_segment.py
+++ b/pipescaler/core/pipelines/checkpointed_segment.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Sequence
+from collections.abc import Sequence
 
 from pipescaler.core.pipelines.checkpoint_manager_base import CheckpointManagerBase
 from pipescaler.core.pipelines.segment import Segment


### PR DESCRIPTION
## Summary
- replace deprecated Sequence import with collections.abc version

## Testing
- `uv run ruff check pipescaler/core/pipelines/checkpointed_segment.py`
- `uv run pyright` *(fails: 16 errors)*
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d5fb5d324832589722e22d1fe2b02