### PR TITLE
Fix docstring typo

### DIFF
--- a/pipescaler/image/utilities/local_palette_matcher.py
+++ b/pipescaler/image/utilities/local_palette_matcher.py
@@ -61,7 +61,7 @@ class LocalPaletteMatcher(Utility):
               1 checks a 3x3 window, 2 checks a 5x5 window, etc.
 
         Returns:
-            Matched imaged array
+            Matched image array
         """
         scale = fit_array.shape[0] // ref_array.shape[0]
         matched_array = np.zeros_like(fit_array)
@@ -107,7 +107,7 @@ class LocalPaletteMatcher(Utility):
               1 checks a 3x3 window, 2 checks a 5x5 window, etc.
 
         Returns:
-            Matched imaged array
+            Matched image array
         """
         scale = fit_array.shape[0] // ref_array.shape[0]
         matched_array = np.zeros_like(fit_array)


### PR DESCRIPTION
## Summary
- fix typo in LocalPaletteMatcher docstrings

## Testing
- `uv run black .`
- `uv run ruff check .` *(fails: D103, D415, D205, D103 etc.)*
- `uv run pyright` *(fails: attribute access issues, type errors)*
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687806f3d13c8325a34e44a7ccea64a8