### PR TITLE
Fix docstring typo

### DIFF
--- a/pipescaler/image/utilities/palette_matcher.py
+++ b/pipescaler/image/utilities/palette_matcher.py
@@ -197,7 +197,7 @@ class PaletteMatcher(Utility):
         Returns:
             dict whose keys are a tuple of cell_to_check coordinates in the red, green
             and blue dimensions, and whose values are an rgb_array of palette colors
-            each chell
+            each cell contains
         """
         palette_by_cell_list: dict[tuple[int, int, int], list[int]] = {}
 


### PR DESCRIPTION
## Summary
- update palette matcher docstring spelling

## Testing
- `uv run ruff check .`
- `uv run pyright`
- `uv run black .`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6878038773608325b6d8387e1ce4d236