### PR TITLE
Add __all__ lists to remaining packages

### DIFF
--- a/pipescaler/image/core/analytics/__init__.py
+++ b/pipescaler/image/core/analytics/__init__.py
@@ -2,3 +2,10 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler image core analytics package."""
 from __future__ import annotations
+
+from pipescaler.image.core.analytics import hashing, typing
+
+__all__ = [
+    "hashing",
+    "typing",
+]

--- a/pipescaler/image/operators/__init__.py
+++ b/pipescaler/image/operators/__init__.py
@@ -1,3 +1,12 @@
 #  Copyright 2020-2024 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler image operators package."""
+from __future__ import annotations
+
+from pipescaler.image.operators import mergers, processors, splitters
+
+__all__ = [
+    "mergers",
+    "processors",
+    "splitters",
+]

--- a/pipescaler/testing/__init__.py
+++ b/pipescaler/testing/__init__.py
@@ -2,3 +2,12 @@
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler general testing package."""
 from __future__ import annotations
+
+from pipescaler.testing import execution_counter, file, fixture, mark
+
+__all__ = [
+    "execution_counter",
+    "file",
+    "fixture",
+    "mark",
+]

--- a/pipescaler/video/__init__.py
+++ b/pipescaler/video/__init__.py
@@ -1,3 +1,12 @@
 #  Copyright 2020-2024 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler video package; contains code specific to video processing."""
+from __future__ import annotations
+
+from pipescaler.video import core, pipelines, runners
+
+__all__ = [
+    "core",
+    "pipelines",
+    "runners",
+]

--- a/pipescaler/video/core/__init__.py
+++ b/pipescaler/video/core/__init__.py
@@ -1,3 +1,10 @@
 #  Copyright 2020-2024 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler video core package."""
+from __future__ import annotations
+
+from pipescaler.video.core import pipelines
+
+__all__ = [
+    "pipelines",
+]

--- a/pipescaler/video/pipelines/__init__.py
+++ b/pipescaler/video/pipelines/__init__.py
@@ -1,3 +1,12 @@
 #  Copyright 2020-2024 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
 """PipeScaler video pipelines package."""
+from __future__ import annotations
+
+from pipescaler.video.pipelines import sources, sorters, termini
+
+__all__ = [
+    "sources",
+    "sorters",
+    "termini",
+]


### PR DESCRIPTION
## Summary
- expose public submodules in packages missing `__all__`

## Testing
- `uv run black .`
- `uv run ruff check .` *(fails: Type alias uses `type` etc.)*
- `uv run pyright` *(fails: 16 errors)*
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68780381a484832588b1687e8b6f55d5