### PR TITLE
Add processor plugin entry point support

### DIFF
--- a/pipescaler/image/cli/image_mergers_cli.py
+++ b/pipescaler/image/cli/image_mergers_cli.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from importlib.metadata import entry_points
 from typing import Any
 
 from pipescaler.common import CommandLineInterface
@@ -58,11 +59,19 @@ class ImageMergersCli(CommandLineInterface):
     @classmethod
     def mergers(cls) -> dict[str, type[ImageMergerCli]]:
         """Names and types of mergers wrapped by command-line interface."""
-        return {
+        builtins = {
             merger.name(): merger
             for merger in map(mergers.__dict__.get, mergers.__all__)
             if isinstance(merger, type) and issubclass(merger, ImageMergerCli)
         }
+
+        extras = {}
+        for entry_point in entry_points(group="pipescaler.image.mergers"):
+            merger = entry_point.load()
+            if isinstance(merger, type) and issubclass(merger, ImageMergerCli):
+                extras[merger.name()] = merger
+
+        return builtins | extras
 
 
 if __name__ == "__main__":

--- a/pipescaler/image/cli/image_splitters_cli.py
+++ b/pipescaler/image/cli/image_splitters_cli.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from importlib.metadata import entry_points
 from typing import Any
 
 from pipescaler.common import CommandLineInterface
@@ -58,11 +59,19 @@ class ImageSplittersCli(CommandLineInterface):
     @classmethod
     def splitters(cls) -> dict[str, type[ImageSplitterCli]]:
         """Names and types of splitters wrapped by command-line interface."""
-        return {
+        builtins = {
             splitter.name(): splitter
             for splitter in map(splitters.__dict__.get, splitters.__all__)
             if isinstance(splitter, type) and issubclass(splitter, ImageSplitterCli)
         }
+
+        extras = {}
+        for entry_point in entry_points(group="pipescaler.image.splitters"):
+            splitter = entry_point.load()
+            if isinstance(splitter, type) and issubclass(splitter, ImageSplitterCli):
+                extras[splitter.name()] = splitter
+
+        return builtins | extras
 
 
 if __name__ == "__main__":

--- a/pipescaler/image/cli/image_utilities_cli.py
+++ b/pipescaler/image/cli/image_utilities_cli.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser
+from importlib.metadata import entry_points
 from typing import Any
 
 from pipescaler.common import CommandLineInterface
@@ -58,11 +59,19 @@ class ImageUtilitiesCli(CommandLineInterface):
     @classmethod
     def utilities(cls) -> dict[str, type[UtilityCli]]:
         """Names and types of utilities wrapped by command-line interface."""
-        return {
+        builtins = {
             utility.name(): utility
             for utility in map(utilities.__dict__.get, utilities.__all__)
             if isinstance(utility, type) and issubclass(utility, UtilityCli)
         }
+
+        extras = {}
+        for entry_point in entry_points(group="pipescaler.image.utilities"):
+            utility = entry_point.load()
+            if isinstance(utility, type) and issubclass(utility, UtilityCli):
+                extras[utility.name()] = utility
+
+        return builtins | extras
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,27 @@ convention = 'google'
 
 [tool.setuptools]
 packages = { find = { include = ["pipescaler*"] } }
+
+[project.entry-points."pipescaler.image.processors"]
+crop = "pipescaler.image.cli.processors.crop_cli:CropCli"
+esrgan = "pipescaler.image.cli.processors.esrgan_cli:EsrganCli"
+expand = "pipescaler.image.cli.processors.expand_cli:ExpandCli"
+heighttonormal = "pipescaler.image.cli.processors.height_to_normal_cli:HeightToNormalCli"
+mode = "pipescaler.image.cli.processors.mode_cli:ModeCli"
+resize = "pipescaler.image.cli.processors.resize_cli:ResizeCli"
+sharpen = "pipescaler.image.cli.processors.sharpen_cli:SharpenCli"
+solidcolor = "pipescaler.image.cli.processors.solid_color_cli:SolidColorCli"
+threshold = "pipescaler.image.cli.processors.threshold_cli:ThresholdCli"
+waifu = "pipescaler.image.cli.processors.waifu_cli:WaifuCli"
+xbrz = "pipescaler.image.cli.processors.xbrz_cli:XbrzCli"
+
+[project.entry-points."pipescaler.image.mergers"]
+alphamerger = "pipescaler.image.cli.mergers.alpha_merger_cli:AlphaMergerCli"
+palettematch = "pipescaler.image.cli.mergers.palette_match_merger_cli:PaletteMatchMergerCli"
+
+[project.entry-points."pipescaler.image.splitters"]
+alphasplitter = "pipescaler.image.cli.splitters.alpha_splitter_cli:AlphaSplitterCli"
+
+[project.entry-points."pipescaler.image.utilities"]
+esrganserializer = "pipescaler.image.cli.utilities.esrgan_serializer_cli:EsrganSerializerCli"
+waifuserializer = "pipescaler.image.cli.utilities.waifu_serializer_cli:WaifuSerializerCli"

--- a/test/image/cli/test_image_splitters_cli.py
+++ b/test/image/cli/test_image_splitters_cli.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import importlib.metadata as importlib_metadata
+import sys
+import types
 from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
@@ -16,6 +19,8 @@ from pipescaler.common.file import get_temp_file_path
 from pipescaler.common.testing import run_cli_with_args
 from pipescaler.image.cli import ImageSplittersCli
 from pipescaler.image.cli.splitters import AlphaSplitterCli
+from pipescaler.image.core.cli import ImageSplitterCli
+from pipescaler.image.core.operators import ImageSplitter
 from pipescaler.testing.file import get_test_infile_path
 
 
@@ -26,6 +31,7 @@ from pipescaler.testing.file import get_test_infile_path
     ],
 )
 def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
+    """Run splitter CLI end-to-end."""
     input_path = get_test_infile_path(infile)
 
     with get_temp_file_path(".png") as output_path_1:
@@ -44,6 +50,7 @@ def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
     ],
 )
 def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
+    """Ensure help is displayed for splitters CLI."""
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -69,6 +76,7 @@ def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     ],
 )
 def test_usage(commands: tuple[type[CommandLineInterface], ...]):
+    """Ensure usage error is produced for missing arguments."""
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -83,3 +91,38 @@ def test_usage(commands: tuple[type[CommandLineInterface], ...]):
         assert stderr.getvalue().startswith(
             f"usage: {Path(getfile(commands[0])).name} {subcommands}"
         )
+
+
+def test_entry_point_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure additional splitters are discovered via entry points."""
+
+    class DummySplitter(ImageSplitter):
+        pass
+
+    class DummyCli(ImageSplitterCli):
+        @classmethod
+        def splitter(cls) -> type[DummySplitter]:
+            return DummySplitter
+
+    module = types.ModuleType("dummy_module")
+    setattr(module, "DummyCli", DummyCli)
+    sys.modules["dummy_module"] = module
+
+    ep = importlib_metadata.EntryPoint(
+        name="dummy",
+        value="dummy_module:DummyCli",
+        group="pipescaler.image.splitters",
+    )
+    dummy_eps = importlib_metadata.EntryPoints((ep,))
+
+    def fake_entry_points(*, group: str):
+        if group == "pipescaler.image.splitters":
+            return dummy_eps
+        return importlib_metadata.EntryPoints(())
+
+    monkeypatch.setattr(
+        "pipescaler.image.cli.image_splitters_cli.entry_points", fake_entry_points
+    )
+
+    splitters = ImageSplittersCli.splitters()
+    assert splitters["dummy"] is DummyCli

--- a/test/image/cli/test_image_utilities_cli.py
+++ b/test/image/cli/test_image_utilities_cli.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import importlib.metadata as importlib_metadata
+import sys
+import types
 from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
@@ -14,6 +17,8 @@ import pytest
 from pipescaler.common import CommandLineInterface
 from pipescaler.common.file import get_temp_file_path
 from pipescaler.common.testing import run_cli_with_args
+from pipescaler.core.cli import UtilityCli
+from pipescaler.core.utility import Utility
 from pipescaler.image.cli import ImageUtilitiesCli
 from pipescaler.image.cli.utilities import EsrganSerializerCli, WaifuSerializerCli
 from pipescaler.testing.file import get_test_model_infile_path
@@ -36,6 +41,7 @@ from pipescaler.testing.mark import skip_if_ci, skip_if_codex
     ],
 )
 def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
+    """Run image utility CLI end-to-end."""
     input_path = get_test_model_infile_path(infile)
 
     with get_temp_file_path(".pth") as output_path:
@@ -53,6 +59,7 @@ def test(cli: type[CommandLineInterface], args: str, infile: str) -> None:
     ],
 )
 def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
+    """Ensure help is displayed for utilities CLI."""
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -80,6 +87,7 @@ def test_help(commands: tuple[type[CommandLineInterface], ...]) -> None:
     ],
 )
 def test_usage(commands: tuple[type[CommandLineInterface], ...]):
+    """Ensure usage error is produced for missing arguments."""
     subcommands = " ".join(f"{command.name()}" for command in commands[1:])
 
     stdout = StringIO()
@@ -94,3 +102,38 @@ def test_usage(commands: tuple[type[CommandLineInterface], ...]):
         assert stderr.getvalue().startswith(
             f"usage: {Path(getfile(commands[0])).name} {subcommands}"
         )
+
+
+def test_entry_point_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure additional utilities are discovered via entry points."""
+
+    class DummyUtility(Utility):
+        pass
+
+    class DummyCli(UtilityCli):
+        @classmethod
+        def utility(cls) -> type[DummyUtility]:
+            return DummyUtility
+
+    module = types.ModuleType("dummy_module")
+    setattr(module, "DummyCli", DummyCli)
+    sys.modules["dummy_module"] = module
+
+    ep = importlib_metadata.EntryPoint(
+        name="dummy",
+        value="dummy_module:DummyCli",
+        group="pipescaler.image.utilities",
+    )
+    dummy_eps = importlib_metadata.EntryPoints((ep,))
+
+    def fake_entry_points(*, group: str):
+        if group == "pipescaler.image.utilities":
+            return dummy_eps
+        return importlib_metadata.EntryPoints(())
+
+    monkeypatch.setattr(
+        "pipescaler.image.cli.image_utilities_cli.entry_points", fake_entry_points
+    )
+
+    utilities = ImageUtilitiesCli.utilities()
+    assert utilities["dummy"] is DummyCli


### PR DESCRIPTION
## Summary
- allow discovery of image processor CLI plugins via entry points
- register built-in processors as entry points
- test processor entry point discovery
- add plugin entry point support for image mergers, splitters, and utilities

## Testing
- `uv run ruff format pipescaler/image/cli/image_mergers_cli.py pipescaler/image/cli/image_splitters_cli.py pipescaler/image/cli/image_utilities_cli.py test/image/cli/test_image_mergers_cli.py test/image/cli/test_image_splitters_cli.py test/image/cli/test_image_utilities_cli.py pyproject.toml`
- `uv run ruff check --fix pipescaler/image/cli/image_mergers_cli.py pipescaler/image/cli/image_splitters_cli.py pipescaler/image/cli/image_utilities_cli.py test/image/cli/test_image_mergers_cli.py test/image/cli/test_image_splitters_cli.py test/image/cli/test_image_utilities_cli.py pyproject.toml`
- `uv run pyright pipescaler/image/cli/image_mergers_cli.py pipescaler/image/cli/image_splitters_cli.py pipescaler/image/cli/image_utilities_cli.py test/image/cli/test_image_mergers_cli.py test/image/cli/test_image_splitters_cli.py test/image/cli/test_image_utilities_cli.py`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878fcbe39148325975342ef5564702a