### PR TITLE
Add ImageMode literal type

### DIFF
--- a/pipescaler/image/core/image_operator.py
+++ b/pipescaler/image/core/image_operator.py
@@ -9,6 +9,8 @@ from abc import ABC
 from inspect import cleandoc
 from typing import Any
 
+from pipescaler.image.core.typing import ImageMode
+
 
 class ImageOperator(ABC):
     """Abstract base class for image operators."""
@@ -32,11 +34,11 @@ class ImageOperator(ABC):
         return ""
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         raise NotImplementedError()
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         raise NotImplementedError()

--- a/pipescaler/image/core/operators/processors/pytorch_image_processor.py
+++ b/pipescaler/image/core/operators/processors/pytorch_image_processor.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from pipescaler.common.validation import val_input_path
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image_and_convert_mode
 
 
@@ -85,14 +86,14 @@ class PyTorchImageProcessor(ImageProcessor, ABC):
         return output_arr
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "RGB"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "RGB"),

--- a/pipescaler/image/core/typing.py
+++ b/pipescaler/image/core/typing.py
@@ -1,0 +1,14 @@
+#  Copyright 2020-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Type hints for image processing."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+# Image modes supported by PipeScaler
+# 1-bit, grayscale, grayscale+alpha, palette, RGB, RGBA, HSV
+# Extend this type if additional modes are needed
+
+type ImageMode = Literal["1", "L", "LA", "P", "RGB", "RGBA", "HSV"]
+"""Type alias for supported PIL image mode strings."""

--- a/pipescaler/image/operators/mergers/alpha_merger.py
+++ b/pipescaler/image/operators/mergers/alpha_merger.py
@@ -8,6 +8,7 @@ import numpy as np
 from PIL import Image
 
 from pipescaler.image.core.operators import ImageMerger
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -42,7 +43,7 @@ class AlphaMerger(ImageMerger):
         return output_img
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "color": ("L", "RGB"),
@@ -50,7 +51,7 @@ class AlphaMerger(ImageMerger):
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("LA", "RGBA"),

--- a/pipescaler/image/operators/mergers/histogram_match_merger.py
+++ b/pipescaler/image/operators/mergers/histogram_match_merger.py
@@ -10,6 +10,7 @@ from skimage.exposure import match_histograms
 
 from pipescaler.image.core import UnsupportedImageModeError
 from pipescaler.image.core.operators import ImageMerger
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -44,7 +45,7 @@ class HistogramMatchMerger(ImageMerger):
         return output_img
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "ref": ("L", "LA", "RGB", "RGBA"),
@@ -52,7 +53,7 @@ class HistogramMatchMerger(ImageMerger):
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/mergers/normal_merger.py
+++ b/pipescaler/image/operators/mergers/normal_merger.py
@@ -8,6 +8,7 @@ import numpy as np
 from PIL import Image
 
 from pipescaler.image.core.operators import ImageMerger
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -42,7 +43,7 @@ class NormalMerger(ImageMerger):
         return output_img
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "x": ("L",),
@@ -51,7 +52,7 @@ class NormalMerger(ImageMerger):
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("RGB",),

--- a/pipescaler/image/operators/mergers/palette_match_merger.py
+++ b/pipescaler/image/operators/mergers/palette_match_merger.py
@@ -11,6 +11,7 @@ from PIL import Image
 from pipescaler.common.validation import val_int
 from pipescaler.image.core import PaletteMatchMode, UnsupportedImageModeError
 from pipescaler.image.core.operators import ImageMerger
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 from pipescaler.image.utilities import LocalPaletteMatcher, PaletteMatcher
 
@@ -70,7 +71,7 @@ class PaletteMatchMerger(ImageMerger):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "ref": ("L", "RGB"),
@@ -78,7 +79,7 @@ class PaletteMatchMerger(ImageMerger):
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("L", "RGB"),

--- a/pipescaler/image/operators/processors/crop_processor.py
+++ b/pipescaler/image/operators/processors/crop_processor.py
@@ -9,6 +9,7 @@ from PIL import Image
 from pipescaler.common.validation import val_int
 from pipescaler.image.core.functions import crop_image
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -56,14 +57,14 @@ class CropProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/processors/expand_processor.py
+++ b/pipescaler/image/operators/processors/expand_processor.py
@@ -9,6 +9,7 @@ from PIL import Image
 from pipescaler.common.validation import val_int
 from pipescaler.image.core.functions import expand_image
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -51,14 +52,14 @@ class ExpandProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/processors/height_to_normal_processor.py
+++ b/pipescaler/image/operators/processors/height_to_normal_processor.py
@@ -12,6 +12,7 @@ from pipescaler.image.core.functions import (
     smooth_image,
 )
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -49,14 +50,14 @@ class HeightToNormalProcessor(ImageProcessor):
         return f"{self.__class__.__name__}(sigma={self.sigma!r})"
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("L",),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("RGB",),

--- a/pipescaler/image/operators/processors/mode_processor.py
+++ b/pipescaler/image/operators/processors/mode_processor.py
@@ -8,6 +8,7 @@ from PIL import Image, ImageColor
 
 from pipescaler.common.validation import val_str
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -68,14 +69,14 @@ class ModeProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/processors/potrace_processor.py
+++ b/pipescaler/image/operators/processors/potrace_processor.py
@@ -11,6 +11,7 @@ from svglib.svglib import svg2rlg
 from pipescaler.common.file import get_temp_file_path
 from pipescaler.common.validation import val_float
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image_and_convert_mode
 from pipescaler.image.runners import PotraceRunner
 
@@ -70,7 +71,7 @@ class PotraceProcessor(ImageProcessor):
                 traced_drawing.height = int(input_image.size[1] * self.scale)
 
                 with get_temp_file_path(".png") as temp_png_path:
-                    drawToFile(traced_drawing, temp_png_path, fmt="png")
+                    drawToFile(traced_drawing, temp_png_path, fmt="png")  # pyright: ignore[reportArgumentType]
                     output_image = Image.open(temp_png_path).convert("L")
 
         if self.invert:
@@ -96,14 +97,14 @@ class PotraceProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1",),

--- a/pipescaler/image/operators/processors/resize_processor.py
+++ b/pipescaler/image/operators/processors/resize_processor.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from pipescaler.common.validation import val_float, val_str
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 
 
 class ResizeProcessor(ImageProcessor):
@@ -81,14 +82,14 @@ class ResizeProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/processors/sharpen_processor.py
+++ b/pipescaler/image/operators/processors/sharpen_processor.py
@@ -9,6 +9,7 @@ from PIL import Image
 from scipy.signal import convolve2d
 
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -44,14 +45,14 @@ class SharpenProcessor(ImageProcessor):
         return output_img
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("L", "RGB"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("L", "RGB"),

--- a/pipescaler/image/operators/processors/solid_color_processor.py
+++ b/pipescaler/image/operators/processors/solid_color_processor.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 from pipescaler.common.validation import val_float
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image_and_convert_mode
 
 
@@ -59,14 +60,14 @@ class SolidColorProcessor(ImageProcessor):
         return f"{self.__class__.__name__}(scale={self.scale!r})"
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/processors/threshold_processor.py
+++ b/pipescaler/image/operators/processors/threshold_processor.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from pipescaler.common.validation import val_int
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image_and_convert_mode
 
 
@@ -63,14 +64,14 @@ class ThresholdProcessor(ImageProcessor):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1",),

--- a/pipescaler/image/operators/processors/xbrz_processor.py
+++ b/pipescaler/image/operators/processors/xbrz_processor.py
@@ -10,6 +10,7 @@ from PIL import Image
 
 from pipescaler.common.validation import val_int
 from pipescaler.image.core.operators import ImageProcessor
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image_and_convert_mode
 
 
@@ -63,14 +64,14 @@ class XbrzProcessor(ImageProcessor):
         return "Upscales image using [xbrz](https://github.com/ioistired/xbrz.py)."
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("1", "L", "LA", "RGB", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "output": ("1", "L", "LA", "RGB", "RGBA"),

--- a/pipescaler/image/operators/splitters/alpha_splitter.py
+++ b/pipescaler/image/operators/splitters/alpha_splitter.py
@@ -11,6 +11,7 @@ from pipescaler.common import ArgumentConflictError
 from pipescaler.image.core import AlphaMode, MaskFillMode
 from pipescaler.image.core.functions import is_monochrome
 from pipescaler.image.core.operators import ImageSplitter
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 from pipescaler.image.utilities import MaskFiller
 
@@ -79,14 +80,14 @@ class AlphaSplitter(ImageSplitter):
         )
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("LA", "RGBA"),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "color": ("L", "RGB"),

--- a/pipescaler/image/operators/splitters/normal_splitter.py
+++ b/pipescaler/image/operators/splitters/normal_splitter.py
@@ -8,6 +8,7 @@ import numpy as np
 from PIL import Image
 
 from pipescaler.image.core.operators import ImageSplitter
+from pipescaler.image.core.typing import ImageMode
 from pipescaler.image.core.validation import validate_image
 
 
@@ -36,14 +37,14 @@ class NormalSplitter(ImageSplitter):
         return x_img, y_img, z_img
 
     @classmethod
-    def inputs(cls) -> dict[str, tuple[str, ...]]:
+    def inputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Inputs to this operator."""
         return {
             "input": ("RGB",),
         }
 
     @classmethod
-    def outputs(cls) -> dict[str, tuple[str, ...]]:
+    def outputs(cls) -> dict[str, tuple[ImageMode, ...]]:
         """Outputs of this operator."""
         return {
             "x": ("L",),


### PR DESCRIPTION
## Summary
- define a new `ImageMode` literal for supported PIL modes
- type `ImageOperator` inputs/outputs using `ImageMode`
- apply typing to operators and clean up PotraceProcessor

## Testing
- `uv run ruff format pipescaler/image/operators/processors/potrace_processor.py pipescaler/image/core/typing.py`
- `uv run ruff check --fix pipescaler/image/operators/processors/potrace_processor.py pipescaler/image/core/typing.py`
- `uv run pyright pipescaler/image/core/typing.py pipescaler/image/operators/processors/potrace_processor.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f8eeb9178832581497c5fb134a858